### PR TITLE
Fix missing link

### DIFF
--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -1489,4 +1489,4 @@ As we were researching options for server-rendering React that didn’t involve 
 
 ## Contributing
 
-Please see our [contributing.md](./contributing.md)
+Please see our [contributing.md](https://github.com/zeit/next.js/blob/canary/contributing.md)


### PR DESCRIPTION
This sentence appeared to be copied from this page, so I fixed it.
https://github.com/zeit/next.js/blob/canary/contributing.md