### PR TITLE
Improve rehype-readme and docs styling

### DIFF
--- a/components/docs/docs.mdx
+++ b/components/docs/docs.mdx
@@ -59,7 +59,7 @@ export default () => (
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/basic-css">Basic css</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/basic-css">Basic css</a></li></ul>
 </details>
 
 We bundle [styled-jsx](https://github.com/zeit/styled-jsx) to provide support for isolated scoped CSS. The aim is to support "shadow CSS" similar to Web Components, which unfortunately [do not support server-rendering and are JS-only](https://github.com/w3c/webcomponents/issues/71).
@@ -99,7 +99,7 @@ Please see the [styled-jsx documentation](https://www.npmjs.com/package/styled-j
   <summary>
     <b>Examples</b>
     </summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-styled-components">Styled components</a></li><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-styletron">Styletron</a></li><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-glamor">Glamor</a></li><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-glamorous">Glamorous</a></li><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-cxs">Cxs</a></li><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-aphrodite">Aphrodite</a></li><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-fela">Fela</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-styled-components">Styled components</a></li><li><a target="_blank" href="/examples/with-styletron">Styletron</a></li><li><a target="_blank" href="/examples/with-glamor">Glamor</a></li><li><a target="_blank" href="/examples/with-glamorous">Glamorous</a></li><li><a target="_blank" href="/examples/with-cxs">Cxs</a></li><li><a target="_blank" href="/examples/with-aphrodite">Aphrodite</a></li><li><a target="_blank" href="/examples/with-fela">Fela</a></li></ul>
 </details>
 
 It's possible to use any existing CSS-in-JS solution. The simplest one is inline styles:
@@ -134,8 +134,8 @@ _Note: Don't name the `static` directory anything else. The name is required and
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/head-elements">Head elements</a></li>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/layout-component">Layout component</a></li>
+    <li><a target="_blank" href="/examples/head-elements">Head elements</a></li>
+    <li><a target="_blank" href="/examples/layout-component">Layout component</a></li>
   </ul>
 </details>
 
@@ -182,7 +182,7 @@ _Note: The contents of `<head>` get cleared upon unmounting the component, so ma
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/data-fetch">Data fetch</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/data-fetch">Data fetch</a></li></ul>
 </details>
 
 When you need state, lifecycle hooks or **initial data population** you can export a `React.Component` (instead of a stateless function, like shown above):
@@ -255,7 +255,7 @@ export default Page
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/hello-world">Hello World</a></li>
+    <li><a target="_blank" href="/examples/hello-world">Hello World</a></li>
   </ul>
 </details>
 
@@ -296,7 +296,7 @@ To inject the `pathname`, `query` or `asPath` in your component, you can use [wi
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-url-object-routing">With URL Object Routing</a></li>
+    <li><a target="_blank" href="/examples/with-url-object-routing">With URL Object Routing</a></li>
   </ul>
 </details>
 
@@ -389,8 +389,8 @@ The default behaviour of `<Link>` is to scroll to the top of the page. When ther
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/using-router">Basic routing</a></li>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-loading">With a page loading indicator</a></li>
+    <li><a target="_blank" href="/examples/using-router">Basic routing</a></li>
+    <li><a target="_blank" href="/examples/with-loading">With a page loading indicator</a></li>
   </ul>
 </details>
 
@@ -510,7 +510,7 @@ Router.events.on('routeChangeError', (err, url) => {
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-shallow-routing">Shallow Routing</a></li>
+    <li><a target="_blank" href="/examples/with-shallow-routing">Shallow Routing</a></li>
   </ul>
 </details>
 
@@ -552,7 +552,7 @@ componentDidUpdate(prevProps) {
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/using-with-router">Using the `withRouter` utility</a></li>
+    <li><a target="_blank" href="/examples/using-with-router">Using the `withRouter` utility</a></li>
   </ul>
 </details>
 
@@ -590,7 +590,7 @@ The above `router` object comes with an API similar to [`next/router`](#imperati
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-prefetching">Prefetching</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-prefetching">Prefetching</a></li></ul>
 </details>
 
 Next.js has an API which allows you to prefetch pages.
@@ -681,12 +681,12 @@ export default withRouter(MyLink)
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/custom-server">Basic custom server</a></li>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/custom-server-express">Express integration</a></li>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/custom-server-hapi">Hapi integration</a></li>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/custom-server-koa">Koa integration</a></li>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/parameterized-routing">Parameterized routing</a></li>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/ssr-caching">SSR caching</a></li>
+    <li><a target="_blank" href="/examples/custom-server">Basic custom server</a></li>
+    <li><a target="_blank" href="/examples/custom-server-express">Express integration</a></li>
+    <li><a target="_blank" href="/examples/custom-server-hapi">Hapi integration</a></li>
+    <li><a target="_blank" href="/examples/custom-server-koa">Koa integration</a></li>
+    <li><a target="_blank" href="/examples/parameterized-routing">Parameterized routing</a></li>
+    <li><a target="_blank" href="/examples/ssr-caching">SSR caching</a></li>
   </ul>
 </details>
 
@@ -814,7 +814,7 @@ app.prepare().then(() => {
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-dynamic-import">With Dynamic Import</a></li>
+    <li><a target="_blank" href="/examples/with-dynamic-import">With Dynamic Import</a></li>
   </ul>
 </details>
 
@@ -910,8 +910,8 @@ export default () => <HelloBundle title="Dynamic Bundle" />
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-app-layout">Using `_app.js` for layout</a></li>
-    <li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-componentdidcatch">Using `_app.js` to override `componentDidCatch`</a></li>
+    <li><a target="_blank" href="/examples/with-app-layout">Using `_app.js` for layout</a></li>
+    <li><a target="_blank" href="/examples/with-componentdidcatch">Using `_app.js` to override `componentDidCatch`</a></li>
   </ul>
 </details>
 
@@ -955,8 +955,8 @@ export default class MyApp extends App {
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-styled-components">Styled components custom document</a></li></ul>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-amp">Google AMP</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-styled-components">Styled components custom document</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-amp">Google AMP</a></li></ul>
 </details>
 
 - Is rendered on the server side
@@ -1170,7 +1170,7 @@ module.exports = {
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-webpack-bundle-analyzer">Custom webpack bundle analyzer</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-webpack-bundle-analyzer">Custom webpack bundle analyzer</a></li></ul>
 </details>
 
 Some commonly asked for features are available as modules:
@@ -1253,7 +1253,7 @@ module.exports = {
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-custom-babel-config">Custom babel configuration</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-custom-babel-config">Custom babel configuration</a></li></ul>
 </details>
 
 In order to extend our usage of `babel`, you can simply define a `.babelrc` file at the root of your app. This file is optional.
@@ -1345,7 +1345,7 @@ module.exports = {
 }
 ```
 
-Note: Next.js will automatically use that prefix in the scripts it loads, but this has no effect whatsoever on `/static`. If you want to serve those assets over the CDN, you'll have to introduce the prefix yourself. One way of introducing a prefix that works inside your components and varies by environment is documented [in this example](https://github.com/zeit/next.js/tree/master/examples/with-universal-configuration).
+Note: Next.js will automatically use that prefix in the scripts it loads, but this has no effect whatsoever on `/static`. If you want to serve those assets over the CDN, you'll have to introduce the prefix yourself. One way of introducing a prefix that works inside your components and varies by environment is documented [in this example](/examples/with-universal-configuration).
 
 ## Production deployment
 
@@ -1390,7 +1390,7 @@ The [polyfills](https://github.com/zeit/next.js/tree/canary/examples/with-polyfi
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-static-export">Static export</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-static-export">Static export</a></li></ul>
 </details>
 
 `next export` is a way to run your Next.js app as a standalone static app without the need for a Node.js server.
@@ -1514,7 +1514,7 @@ The `req` and `res` fields of the `context` object passed to `getInitialProps` a
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="https://github.com/zeit/next.js/tree/master/examples/with-zones">With Zones</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-zones">With Zones</a></li></ul>
 </details>
 
 A zone is a single deployment of a Next.js app. Just like that, you can have multiple zones. Then you can merge them as a single app.

--- a/components/docs/docs.mdx
+++ b/components/docs/docs.mdx
@@ -955,8 +955,8 @@ export default class MyApp extends App {
 
 <details>
   <summary><b>Examples</b></summary>
-  <ul><li><a target="_blank" href="/examples/with-styled-components">Styled components custom document</a></li></ul>
-  <ul><li><a target="_blank" href="/examples/with-amp">Google AMP</a></li></ul>
+  <ul><li><a target="_blank" href="/examples/with-styled-components">Styled components custom document</a></li>
+  <li><a target="_blank" href="/examples/with-amp">Google AMP</a></li></ul>
 </details>
 
 - Is rendered on the server side

--- a/components/docs/documentation.js
+++ b/components/docs/documentation.js
@@ -3,7 +3,7 @@ import Router from 'next/router';
 import { format, parse } from 'url';
 import Head from './head';
 import Sidebar from './sidebar';
-import { H1, H2, H3, H4 } from './text/headings';
+import { H1, H2, H3, H4, H5 } from './text/headings';
 import { Blockquote } from './text/quotes';
 import { InlineCode, Code } from './text/code';
 import { GenericLink } from './text/link';
@@ -214,6 +214,9 @@ const Details = ({ children }) => {
       {children}
       <style jsx>{`
         margin: 1rem 0;
+        padding: 0 0.5rem;
+        background: #f9f9f9;
+        overflow: hidden;
       `}</style>
     </details>
   );
@@ -224,8 +227,15 @@ const Summary = ({ children }) => {
     <summary>
       {children}
       <style jsx>{`
-        cursor: pointer;
-        outline: none;
+        summary {
+          cursor: pointer;
+          outline: none;
+          font-weight: 500;
+        }
+
+        summary:hover {
+          opacity: 0.8;
+        }
       `}</style>
     </summary>
   );
@@ -236,6 +246,7 @@ export const components = {
   h2: DocH2,
   h3: DocH3,
   h4: DocH4,
+  h5: H5,
   blockquote: Blockquote,
   code: Code,
   inlineCode: InlineCode,

--- a/components/docs/heading.js
+++ b/components/docs/heading.js
@@ -111,6 +111,11 @@ export default props => {
             display: none;
           }
 
+          :global(h3[data-components-heading]) {
+            border-top: 1px solid #f3f3f3;
+            padding-top: 2rem;
+          }
+
           .target {
             display: block;
             margin-top: -128px;

--- a/components/docs/sidebar.js
+++ b/components/docs/sidebar.js
@@ -140,6 +140,8 @@ export class SidebarNavItem extends Component {
           a {
             display: block;
             color: inherit;
+            line-height: 1.4;
+            margin: 0.4rem 0;
             ${listStyle};
           }
           a:hover {

--- a/components/docs/text/code.js
+++ b/components/docs/text/code.js
@@ -6,7 +6,7 @@ export const Code = ({ children, syntax }) => (
         pre {
           padding: 1.25rem;
           margin: 40px 0;
-          border: 1px solid #eaeaea;
+          border: 1px solid #d8d8d8;
           white-space: pre;
           overflow: auto;
           -webkit-overflow-scrolling: touch;
@@ -47,7 +47,8 @@ export const InlineCode = ({ children, wrap = false }) => (
 
         :global(h2) code,
         :global(h3) code,
-        :global(h4) code {
+        :global(h4) code,
+        :global(h5) code {
           font-size: unset;
           color: inherit;
         }

--- a/components/docs/text/headings.js
+++ b/components/docs/text/headings.js
@@ -1,6 +1,6 @@
 const H1 = ({ children, ...props }) => (
   <h1 {...props}>
-    { children }
+    {children}
 
     <style jsx>{`
       font-size: 1.8rem;
@@ -8,44 +8,51 @@ const H1 = ({ children, ...props }) => (
       margin-top: 0;
     `}</style>
   </h1>
-)
+);
 
 const H2 = ({ children, ...props }) => (
   <h2 {...props}>
-    { children }
+    {children}
 
     <style jsx>{`
       font-size: 1.625rem;
       font-weight: 500;
     `}</style>
   </h2>
-)
+);
 
 const H3 = ({ children, ...props }) => (
   <h3 {...props}>
-    { children }
+    {children}
 
     <style jsx>{`
-      font-size: 1.25rem;
+      font-size: 1.4rem;
       font-weight: 600;
     `}</style>
   </h3>
-)
+);
 
 const H4 = ({ children, ...props }) => (
   <h4 {...props}>
-    { children }
+    {children}
 
     <style jsx>{`
-      font-size: 1rem;
+      font-size: 1.15rem;
       font-weight: 600;
     `}</style>
   </h4>
-)
+);
 
-export {
-  H1,
-  H2,
-  H3,
-  H4
-}
+const H5 = ({ children, ...props }) => (
+  <h5 {...props}>
+    {children}
+
+    <style jsx>{`
+      font-size: 1rem;
+      font-weight: 700;
+      margin-top: 2rem;
+    `}</style>
+  </h5>
+);
+
+export { H1, H2, H3, H4, H5 };

--- a/components/page.js
+++ b/components/page.js
@@ -244,8 +244,7 @@ export default withMediaQuery(({ title, description, children }) => (
         .token.prolog,
         .token.doctype,
         .token.cdata {
-          // color: #008000;
-          color: #068d06;
+          color: #2db52d;
           font-style: italic;
         }
 
@@ -253,6 +252,7 @@ export default withMediaQuery(({ title, description, children }) => (
           opacity: 0.7;
         }
 
+        .token.attr-value,
         .token.string {
           // color: #A31515;
           color: #ca0e0e;
@@ -275,13 +275,12 @@ export default withMediaQuery(({ title, description, children }) => (
 
         .token.atrule,
         .token.keyword,
-        .token.attr-value,
         .language-autohotkey .token.selector,
         .language-json .token.boolean,
         .language-json .token.number,
         code[class*='language-css'] {
-          // color: #0000ff;
-          color: #2525f9;
+          // color: #2525f9;
+          font-weight: 600;
         }
 
         .token.function {
@@ -290,6 +289,7 @@ export default withMediaQuery(({ title, description, children }) => (
         .token.deleted,
         .language-autohotkey .token.tag {
           color: #9a050f;
+          // color: #2b91af;
         }
 
         .token.selector,
@@ -313,7 +313,9 @@ export default withMediaQuery(({ title, description, children }) => (
 
         .token.tag,
         .token.selector {
-          color: #800000;
+          // color: #800000;
+          // color: #9a050f;
+          color: #2b91af;
         }
 
         .token.attr-name,

--- a/lib/rehype-readme.js
+++ b/lib/rehype-readme.js
@@ -7,6 +7,8 @@ const GitHubSlugger = require('github-slugger');
  * 2. relative images => github images
  */
 const ABSOLUTE_URL = /^https?:\/\/|^\/\//i;
+const resolveURL = (base, href) => url.resolve(base, href.replace(/^\//, ''));
+
 const toAbsoluteURL = ({ repo, img }) => node => {
   // match relative url
   if (node.properties) {
@@ -14,9 +16,9 @@ const toAbsoluteURL = ({ repo, img }) => node => {
       node.tagName === 'a' ? node.properties.href : node.properties.src;
     if (href && href[0] !== '#' && !ABSOLUTE_URL.test(href)) {
       if (node.tagName === 'a') {
-        node.properties.href = url.resolve(repo, href);
+        node.properties.href = resolveURL(repo, href);
       } else {
-        node.properties.src = url.resolve(img, href);
+        node.properties.src = resolveURL(img, href);
       }
     }
   }
@@ -29,8 +31,8 @@ const C_TAB = '\t';
 const C_SPACE = ' ';
 const C_NEWLINE = '\n';
 
-const detailsTokenizer = name =>
-  function(eat, value) {
+function generateTokenizer(name, repo) {
+  return function(eat, value) {
     let index = 0;
     let length = value.length;
     let next;
@@ -91,6 +93,27 @@ const detailsTokenizer = name =>
       .map(str => str.trim())
       .join('\n');
 
+    // match links inside html (`<a></a>`)
+    content = content.replace(/<a([^>]*)(>[^<]+<\/a>)/g, function(
+      str,
+      attr,
+      rest
+    ) {
+      attr = attr.replace(/href=(['"])([^'"]*)\1/, function(str, quote, href) {
+        if (href && href[0] !== '#' && !ABSOLUTE_URL.test(href)) {
+          return 'href=' + quote + resolveURL(repo, href) + quote;
+        }
+        return 'href=' + quote + href + quote;
+      });
+
+      // add target='_blank'
+      if (!attr.match(/target=['"]_blank\1/)) {
+        attr += ' target="_blank"';
+      }
+
+      return '<a' + attr + rest;
+    });
+
     // return mdast with hast data
     let data = {
       type: name,
@@ -111,6 +134,7 @@ const detailsTokenizer = name =>
 
     return eat(subvalue)(data);
   };
+}
 
 /**
  * Generate headings list
@@ -190,8 +214,8 @@ const readme = function(options) {
   const Parser = this.Parser;
 
   const tokenizers = Parser.prototype.blockTokenizers;
-  tokenizers.details = detailsTokenizer('details');
-  tokenizers.summary = detailsTokenizer('summary');
+  tokenizers.details = generateTokenizer('details', repo);
+  tokenizers.summary = generateTokenizer('summary', repo);
 
   const methods = Parser.prototype.blockMethods;
   methods.splice(methods.indexOf('html'), 0, 'summary');


### PR DESCRIPTION
- Fix relative URLs inside `<details>` for rehype-readme.
- Revert the docs.mdx changes due to the previous hotfix.
- Improved docs styling.
