### PR TITLE
Fix SVG rendering in Windows

### DIFF
--- a/components/logo.js
+++ b/components/logo.js
@@ -9,7 +9,7 @@ export default withPure(({ size }) => (
     xmlnsXlink="http://www.w3.org/1999/xlink"
     style={{
       // visually centering
-      transform: 'translateX(4%)'
+      transform: 'translateX(4%) rotate(-.5deg)'
     }}
   >
     <path

--- a/components/page.js
+++ b/components/page.js
@@ -329,6 +329,15 @@ export default withMediaQuery(({ title, description, children }) => (
           background: #ffff00;
           color: #393a34;
         }
+
+        svg {
+          shape-rendering: crispEdges;
+        }
+
+        svg path,
+        svg circle {
+          shape-rendering: geometricprecision;
+        }
       `}
     </style>
     {children}


### PR DESCRIPTION
Use a trick to make logos / icons look better.

## old
![image](https://user-images.githubusercontent.com/3676859/46949849-61025180-d0b5-11e8-8aa2-c7d86c7de4c5.png)
![image](https://user-images.githubusercontent.com/3676859/46949828-51830880-d0b5-11e8-8b85-e1f0c436dcbf.png)

## new
![image](https://user-images.githubusercontent.com/3676859/46949869-6f506d80-d0b5-11e8-8f7a-685957a16da3.png)
![image](https://user-images.githubusercontent.com/3676859/46949897-82fbd400-d0b5-11e8-8c1c-b89e9c305e48.png)
