### PR TITLE
Fix license link

### DIFF
--- a/site-manifest.js
+++ b/site-manifest.js
@@ -1,4 +1,4 @@
 export const links = {
   spectrum: 'https://spectrum.chat/next-js',
-  license: 'https://github.com/zeit/next.js/blob/canary/license.md'
+  license: 'https://github.com/zeit/next.js/blob/canary/packages/next/license.md'
 }


### PR DESCRIPTION
The previous link was pointing to the main license of the project.
This link points to next package instead of next-server.