### PR TITLE
Fix syntax highlighting for docs and blog

### DIFF
--- a/components/css-config.js
+++ b/components/css-config.js
@@ -7,4 +7,4 @@ export const FONT_FAMILY_MONO =
 export const COLOR_ERROR = '#FF001F';
 export const COLOR_SUCCESS = '#067DF7';
 
-export const COLOR_CODE_LIGHT = '#D400FF';
+export const COLOR_CODE_LIGHT = '#000';

--- a/components/page.js
+++ b/components/page.js
@@ -228,7 +228,7 @@ export default withMediaQuery(({ title, description, children }) => (
 
         code[class*='language-'],
         pre[class*='language-'] {
-          color: #393a34;
+          color: #000;
           direction: ltr;
           text-align: left;
           white-space: pre;
@@ -239,92 +239,93 @@ export default withMediaQuery(({ title, description, children }) => (
           tab-size: 4;
           hyphens: none;
         }
-
         .token.comment,
         .token.prolog,
         .token.doctype,
         .token.cdata {
-          color: #2db52d;
-          font-style: italic;
+          color: #999;
         }
-
         .token.namespace {
           opacity: 0.7;
         }
-
-        .token.attr-value,
         .token.string {
-          // color: #A31515;
-          color: #ca0e0e;
+          color: #028265;
         }
-
+        .token.attr-value,
         .token.punctuation,
         .token.operator {
-          color: #393a34; /* no highlight */
+          color: #000;
         }
-
         .token.url,
         .token.symbol,
-        .token.number,
         .token.boolean,
         .token.variable,
         .token.constant,
         .token.inserted {
           color: #36acaa;
         }
-
         .token.atrule,
-        .token.keyword,
         .language-autohotkey .token.selector,
         .language-json .token.boolean,
-        .language-json .token.number,
         code[class*='language-css'] {
-          // color: #2525f9;
           font-weight: 600;
         }
-
-        .token.function {
-          color: #393a34;
+        .language-json .token.boolean {
+          color: #0076ff;
+        }
+        .token.keyword {
+          color: #ff0078;
+          font-weight: bolder;
+        }
+        .token.function,
+        .token.tag,
+        .token.class-name,
+        .token.number {
+          color: #0076ff;
         }
         .token.deleted,
         .language-autohotkey .token.tag {
           color: #9a050f;
-          // color: #2b91af;
         }
-
         .token.selector,
         .language-autohotkey .token.keyword {
           color: #00009f;
         }
-
         .token.important,
         .token.bold {
           font-weight: bold;
         }
-
         .token.italic {
           font-style: italic;
         }
-
-        .token.class-name,
-        .language-json .token.property {
-          color: #2b91af;
+        .language-json .token.property,
+        .language-markdown .token.title {
+          color: #000;
+          font-weight: bolder;
         }
-
-        .token.tag,
+        .language-markdown .token.code {
+          color: #0076ff;
+          font-weight: normal;
+        }
+        .language-markdown .token.list,
+        .language-markdown .token.hr {
+          color: #999;
+        }
+        .language-markdown .token.url {
+          color: #ff0078;
+          font-weight: bolder;
+        }
         .token.selector {
-          // color: #800000;
-          // color: #9a050f;
           color: #2b91af;
         }
-
-        .token.attr-name,
         .token.property,
-        .token.regex,
         .token.entity {
           color: #ff0000;
         }
-
+        .token.attr-name,
+        .token.regex {
+          color: #d9931e;
+        }
         .token.directive.tag .tag {
           background: #ffff00;
           color: #393a34;

--- a/pages/blog/next-5-1.mdx
+++ b/pages/blog/next-5-1.mdx
@@ -62,7 +62,7 @@ module.exports = {
 ```
 <Caption>Both <Caption.Code>serverRuntimeConfig</Caption.Code> and <Caption.Code>publicRuntimeConfig</Caption.Code> are defined in <Caption.Code>next.config.js</Caption.Code></Caption>
 
-```js
+```jsx
 // pages/index.js
 import getConfig from 'next/config'
 const {serverRuntimeConfig, publicRuntimeConfig} = getConfig()
@@ -94,7 +94,7 @@ Some [next-plugins](https://github.com/zeit/next-plugins) like [`@zeit/next-css`
 
 You can now export a function that returns the configuration object instead of immediately exporting the object.
 
-```
+```js
 module.exports = (phase, {defaultConfig}) => config
 ```
 <Caption><Caption.Code>next.config.js</Caption.Code> exporting a function that returns the user configuration</Caption>

--- a/pages/blog/next-5.mdx
+++ b/pages/blog/next-5.mdx
@@ -364,7 +364,7 @@ Next.js build a top-level `<Document>` component that gets server-rendered with 
 
 Part of that initial markup is the list of scripts that Next.js needs to evaluate on the client side. A custom `_document` looks like this:
 
-```js
+```jsx
 import Document, { Head, Main, NextScript } from 'next/document'
 export default class extends Document {
   render() {
@@ -376,7 +376,7 @@ export default class extends Document {
           <NextScript />
         </body>
       </html>
-   )
+    )
   }
 }
 ```

--- a/pages/blog/next-6-1.mdx
+++ b/pages/blog/next-6-1.mdx
@@ -69,7 +69,7 @@ When Next.js 6.0 was released the magically injected `url` property on page comp
 
 The recommended way to get the same properties the `url` property had is using `withRouter`:
 
-```js
+```jsx
 // old
 class Page extends React.Component {
   render() {
@@ -81,7 +81,7 @@ export default Page
 ```
 <Caption>How the pathname was accessed in versions before Next.js 6 using <Caption.Code>url</Caption.Code></Caption>
 
-```js
+```jsx
 // new
 import { withRouter } from 'next/router'
 class Page extends React.Component {

--- a/pages/blog/next-6.mdx
+++ b/pages/blog/next-6.mdx
@@ -105,7 +105,7 @@ We have upgraded Babel to its latest version: 7. With it comes some great new fe
 
 React 16.2 introduced the `Fragment` API, which allows you to express a list of elements without having to wrap them in an arbitrary HTML element like `<div>`:
 
-```javascript
+```jsx
 render() {
   return <React.Fragment>
     <A />,
@@ -116,7 +116,7 @@ render() {
 
 Writing this can be tedious, with Next.js 6 you can use the new JSX fragment syntax to facilitate creating fragments:
 
-```javascript
+```jsx
 render() {
   return <>
     <A />,
@@ -131,7 +131,7 @@ If you have a directory nested in your Next.js applications that require a diffe
 
 ```
 src/
-	.babelrc      # General .babelrc
+  .babelrc      # General .babelrc
   components/
     i18n/
       .babelrc  # This .babelrc only applies to this directory

--- a/pages/blog/next-7.mdx
+++ b/pages/blog/next-7.mdx
@@ -129,13 +129,13 @@ With webpack 4, a new way of extracting CSS from bundles was introduced, called 
 
 The new version of these Next.js plugins **solves 20 existing issues related to CSS imports**; As an example,  importing CSS in dynamic `import()`s is now supported:
 
-```js
+```jsx
 // components/my-dynamic-component.js
 import './my-dynamic-component.css'
 export default () => <h1>My dynamic component</h1>
 ```
 
-```js
+```jsx
 // pages/index.js
 import dynamic from 'next/dynamic'
 const MyDynamicComponent = dynamic(import('../components/my-dynamic-component'))
@@ -181,7 +181,7 @@ Starting with Next.js 7 we no longer touch the default `import()` behavior. This
 
 This change is fully backwards-compatible as well. Making use of a dynamic component remains as simple as:
 
-```javascript
+```jsx
 import dynamic from 'next/dynamic'
 const MyComponent = dynamic(import('../components/my-component'))
 export default () => {
@@ -324,7 +324,7 @@ We are excited to introduce styled-jsx 3, the by default included CSS-in-JS solu
 
 One thing that was often unclear was how to style a child component if that component is not part of the current component scope, for example, if you included a child component that needed specific styles only when used inside the parent component:
 
-```javascript
+```jsx
 const ChildComponent = () => <div>
   <p>some text</p>
 </div>
@@ -342,7 +342,7 @@ The above code tries to select the `p` tag does not work because styled-jsx styl
 In styled-jsx 3 this issue has been solved by introducing a new API, `css.resolve`, which will generate the `className` and `<style>`
  tags (the `styles` property) for the given styled-jsx string:
 
-```javascript
+```jsx
 import css from 'styled-jsx/css'
 
 const ChildComponent = ({className}) => <div>


### PR DESCRIPTION
Update syntax highlighting styles of /docs and /blog to keep it the same as zeit.co.