### PR TITLE
Updated docs.mdx to fix an internal link

### DIFF
--- a/www/components/docs/docs.mdx
+++ b/www/components/docs/docs.mdx
@@ -137,7 +137,7 @@ function HiThere() {
 export default HiThere
 ```
 
-To use more sophisticated CSS-in-JS solutions, you typically have to implement style flushing for server-side rendering. We enable this by allowing you to define your own [custom `<Document>`](#user-content-custom-document) component that wraps each page.
+To use more sophisticated CSS-in-JS solutions, you typically have to implement style flushing for server-side rendering. We enable this by allowing you to define your own [custom `<Document>`](#custom-document) component that wraps each page.
 
 #### Importing CSS / Sass / Less / Stylus files
 


### PR DESCRIPTION
The link to "Custom Document" in "CSS-in-JS" section is broken.
Apparently the anchor has been renamed from `/#user-content-custom-document` to `/#custom-document`.