### PR TITLE
[a11y] <ul> elements should only contain <li> elements

### DIFF
--- a/www/components/docs/sidebar.js
+++ b/www/components/docs/sidebar.js
@@ -104,9 +104,16 @@ export function SidebarNavItemContainer({ headings }) {
   if (Array.isArray(headings)) {
     return (
       <ul>
-        {headings.map((item, i) => (
-          <SidebarNavItemContainer headings={item} key={i} />
-        ))}
+        {headings.map((item, i) => {
+          if (Array.isArray(item)) {
+            return (
+              <li>
+                <SidebarNavItemContainer headings={item} key={i} />
+              </li>
+            );
+          }
+          return <SidebarNavItemContainer headings={item} key={i} />;
+        })}
         <style jsx>{`
           ul {
             margin: 0 0 0.5rem 0;


### PR DESCRIPTION
<img width="439" alt="image" src="https://user-images.githubusercontent.com/54012/55129045-e82b0b00-50d2-11e9-8b89-3c341f48f1c4.png">

On https://nextjs.org/docs/ pages the sidebar contains an unordered list that has direct unordered list elements. This is bad for accessibility because screen readers have a hard time reading the lists for the reader when the list isn't formatted correctly [*ref](https://dequeuniversity.com/rules/axe/3.0/list?application=axeAPI)

I fixed this by wrapping the `SidebarNavItemContainer` component with a `<li>` when the item headings being passed in is still an array.

@timneutkens @rauchg @evilrabbit 