### PR TITLE
Fix dynamic import (multiple modules) code example

### DIFF
--- a/www/components/docs/docs.mdx
+++ b/www/components/docs/docs.mdx
@@ -1134,8 +1134,8 @@ import dynamic from 'next/dynamic';
 const HelloBundle = dynamic({
   modules: () => {
     const components = {
-      Hello1: () => import('../components/hello1'),
-      Hello2: () => import('../components/hello2')
+      Hello1: import('../components/hello1'),
+      Hello2: import('../components/hello2')
     };
 
     return components;


### PR DESCRIPTION
This PR fixes the code example for `Dynamic Import` -> `With Multiple
Modules At Once`.

The `dynamic` method takes a `modules` parameter, which should be an
object. Each value in the object should be the `import` statement
itself [1], but the previous example used a function which _returned_
the import statement.

[1] https://github.com/zeit/next.js/blob/c4220d2cd701f25c0ddf68db11b4ea5118d1c7a9/examples/with-dynamic-import/pages/index.js#L28-L42