### PR TITLE
The npm start command seems to miss the run command

### DIFF
--- a/learn/pages/learn/basics/deploying-a-nextjs-app/run-two-instances.mdx
+++ b/learn/pages/learn/basics/deploying-a-nextjs-app/run-two-instances.mdx
@@ -39,12 +39,12 @@ npm run build
 Then try to run the following commands in its own terminal:
 
 ```
-PORT=8000 npm start
-PORT=9000 npm start
+PORT=8000 npm run start
+PORT=9000 npm run start
 ```
 
 > On Windows, you will need to run the commands differently. One option is to install the npm module [`cross-env`](https://www.npmjs.com/package/cross-env) into your app.
-> Then run these two commands from the command line: `cross-env PORT=8000 npm start` and `cross-env PORT=9000 npm start`
+> Then run these two commands from the command line: `cross-env PORT=8000 npm run start` and `cross-env PORT=9000 npm run start`
 
 Is it possible to access our app on both ports?
 


### PR DESCRIPTION
The diff should be self explanatory.
