### PR TITLE
Fix MyLayout imports on learn / basics

### DIFF
--- a/learn/pages/learn/basics/clean-urls-with-route-masking/route-masking.mdx
+++ b/learn/pages/learn/basics/clean-urls-with-route-masking/route-masking.mdx
@@ -26,7 +26,7 @@ Let's add a route mask to our blog post URL.
 Use the following code for the `pages/index.js`:
 
 ```js
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 import Link from 'next/link'
 
 const PostLink = props => (

--- a/learn/pages/learn/basics/create-dynamic-pages/adding-a-list-of-posts.mdx
+++ b/learn/pages/learn/basics/create-dynamic-pages/adding-a-list-of-posts.mdx
@@ -23,7 +23,7 @@ First of all, let's add the list of post titles in the home page.
 Add the following content to the `pages/index.js.`
 
 ```js
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 import Link from 'next/link'
 
 const PostLink = props => (

--- a/learn/pages/learn/basics/create-dynamic-pages/passing-data.mdx
+++ b/learn/pages/learn/basics/create-dynamic-pages/passing-data.mdx
@@ -43,7 +43,7 @@ Create a file called `pages/post.js` and add the following content:
 
 ```js
 import { withRouter } from 'next/router'
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 
 const Page = withRouter(props => (
   <Layout>
@@ -71,7 +71,7 @@ Let's do a simple modification to our app. Replace the content of the “pages/p
 
 ```js
 import { withRouter } from 'next/router'
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 
 const Content = props => (
   <div>

--- a/learn/pages/learn/basics/create-dynamic-pages/with-router.mdx
+++ b/learn/pages/learn/basics/create-dynamic-pages/with-router.mdx
@@ -18,7 +18,7 @@ That's because we're injecting the `router` property into the `Page` component b
 
 ```js
 import { withRouter } from 'next/router'
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 
 const Content = withRouter(props => (
   <div>

--- a/learn/pages/learn/basics/fetching-data-for-pages/fetching-batman-shows.mdx
+++ b/learn/pages/learn/basics/fetching-data-for-pages/fetching-batman-shows.mdx
@@ -34,7 +34,7 @@ npm install --save isomorphic-unfetch
 Then replace our `pages/index.js` with the following content:
 
 ```bash
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 import Link from 'next/link'
 import fetch from 'isomorphic-unfetch'
 

--- a/learn/pages/learn/basics/fetching-data-for-pages/fetching-data-for-pages.mdx
+++ b/learn/pages/learn/basics/fetching-data-for-pages/fetching-data-for-pages.mdx
@@ -38,7 +38,7 @@ Then restart your app to apply the above code change.
 Now replace the `pages/post.js` with the following content:
 
 ```js
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 import fetch from 'isomorphic-unfetch'
 
 const Post = props => (

--- a/learn/pages/learn/basics/styling-components/global-styles.mdx
+++ b/learn/pages/learn/basics/styling-components/global-styles.mdx
@@ -26,7 +26,7 @@ This is where global styles come in handy. Now try to add some global style rule
 > Before you apply the following content, install [react-markdown](https://github.com/rexxars/react-markdown) component into your app with: `npm install --save react-markdown`
 
 ```js
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 import { withRouter } from 'next/router'
 import Markdown from 'react-markdown'
 

--- a/learn/pages/learn/basics/styling-components/styles-and-nested-components.mdx
+++ b/learn/pages/learn/basics/styling-components/styles-and-nested-components.mdx
@@ -22,7 +22,7 @@ export const meta = {
 Now let's add a simple change to our home page. We have isolated our link component like this:
 
 ```js
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 import Link from 'next/link'
 
 function getPosts() {

--- a/learn/pages/learn/basics/styling-components/styling-our-home-page.mdx
+++ b/learn/pages/learn/basics/styling-components/styling-our-home-page.mdx
@@ -24,7 +24,7 @@ Now let's add some styles into our home page. (`pages/index.js`)
 Simply replace `pages/index.js` with the following code:
 
 ```js
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 import Link from 'next/link'
 
 function getPosts() {

--- a/learn/pages/learn/basics/using-shared-components/rendering-children-components.mdx
+++ b/learn/pages/learn/basics/using-shared-components/rendering-children-components.mdx
@@ -94,7 +94,7 @@ export default Layout
 ```js
 // pages/index.js
 
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 
 const indexPageContent = <p>Hello Next.js</p>
 
@@ -106,7 +106,7 @@ export default function Index() {
 ```js
 // pages/about.js
 
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 
 const aboutPageContent = <p>This is the about page</p>
 

--- a/learn/pages/learn/basics/using-shared-components/the-layout-component.mdx
+++ b/learn/pages/learn/basics/using-shared-components/the-layout-component.mdx
@@ -47,7 +47,7 @@ Once we've done that, we can use this Layout in our pages as follows:
 ```js
 // pages/index.js
 
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 
 export default function Index() {
   return (
@@ -61,7 +61,7 @@ export default function Index() {
 ```js
 // pages/about.js
 
-import Layout from '../components/MyLayout.js'
+import Layout from '../components/MyLayout'
 
 export default function About() {
   return (


### PR DESCRIPTION
MyLayout component imports on learn basics tutorial were using the `.js` file extension which was trowing a `eslint(import/extensions)` error.