### PR TITLE
Fix npm scripts section code

### DIFF
--- a/learn/pages/learn/basics/getting-started/setup.mdx
+++ b/learn/pages/learn/basics/getting-started/setup.mdx
@@ -40,13 +40,11 @@ mkdir pages
 Then open the "package.json" in the hello-next directory and add the following NPM script.
 
 ```json
-{
-  "scripts": {
-    "dev": "next",
-    "build": "next build",
-    "start": "next start"
-  }
-}
+ "scripts": {
+   "dev": "next",
+   "build": "next build",
+   "start": "next start"
+ }
 ```
 
 Now everything is ready. Run the following command to start the dev server:


### PR DESCRIPTION
We want the user to add only the `scripts` JSON field and not the root field as is shown currently, which can be misleading to beginners