### PR TITLE
#344 - Updated links

### DIFF
--- a/www/pages/learn/basics/getting-started/finally.mdx
+++ b/www/pages/learn/basics/getting-started/finally.mdx
@@ -13,6 +13,6 @@ Seems like you've built your first Next.js app! What do you think?
 If you like it, let's dive deeper.
 
 If not, just let us know.
-You can post an [issue](https://github.com/zeit/next.js/issues) on our [GitHub repo](https://github.com/zeit/next.js) or join our community on [Spectrum](https://spectrum.chat/next-js).
+You can post an [issue](https://github.com/zeit/next-site/issues) on our [GitHub repo](https://github.com/zeit/next-site) or join our community on [Spectrum](https://spectrum.chat/next-js).
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;


### PR DESCRIPTION
Resolved #344 

Updated links to point to https://github.com/zeit/next-site instead of https://github.com/zeit/next.js at https://nextjs.org/learn/basics/getting-started/finally