### PR TITLE
fix: correct run command to use the server

### DIFF
--- a/www/pages/learn/basics/server-side-support-for-clean-urls/create-a-custom-server.mdx
+++ b/www/pages/learn/basics/server-side-support-for-clean-urls/create-a-custom-server.mdx
@@ -72,7 +72,7 @@ Now update your npm dev script to:
 > On Windows, `NODE_ENV=production` will not work by default. One solution is to install the npm module [`cross-env`](https://www.npmjs.com/package/cross-env) into your app.
 > Then update the `start` script like this: `"start": "cross-env NODE_ENV=production node server.js"`
 
-Now try to run your app again with `npm run dev`.
+Now try to run your app again with `npm run start`.
 
 What's the experience you will get?
 


### PR DESCRIPTION
`npm run dev` would still use client-side only without having anything to do with the server.js.
It has to be `npm run start` to serve using Express backend.