### PR TITLE
fix typo to import MyLayout component

### DIFF
--- a/www/pages/learn/basics/clean-urls-with-dynamic-routing/dynamic-routing.mdx
+++ b/www/pages/learn/basics/clean-urls-with-dynamic-routing/dynamic-routing.mdx
@@ -25,7 +25,7 @@ Let's create our first dynamic route by adding a new page to `pages/p/[id].js`, 
 
 ```jsx
 import { useRouter } from 'next/router';
-import Layout from '../components/MyLayout.js';
+import Layout from '../../components/MyLayout.js';
 
 export default function Post() {
   const router = useRouter();


### PR DESCRIPTION
Previously, the import statement in `p/[id].js` page wasn't referencing the `MyLayout` component correctly. This commit adds an extra `../` to fix that.