### PR TITLE
Add import statement for isomorphic-unfetch to example

### DIFF
--- a/www/components/docs/docs.mdx
+++ b/www/components/docs/docs.mdx
@@ -306,6 +306,8 @@ When you need state, lifecycle hooks or **initial data population** you can expo
 Using a stateless function:
 
 ```jsx
+import fetch from 'isomorphic-unfetch';
+
 function Page({ stars }) {
   return <div>Next stars: {stars}</div>;
 }


### PR DESCRIPTION
Following this example confused me at first because it looked like it was using native `fetch`, and when that didn't work server-side I wasn't sure if that was my mistake or an issue with the docs.