### PR TITLE
Make userAgent optional

### DIFF
--- a/pages/learn/excel/typescript/page-types.mdx
+++ b/pages/learn/excel/typescript/page-types.mdx
@@ -16,7 +16,7 @@ Let's add the `NextPage` type to `Home`:
 ```tsx
 import { NextPage } from 'next';
 
-const Home: NextPage<{ userAgent: string }> = ({ userAgent }) => (
+const Home: NextPage<{ userAgent?: string }> = ({ userAgent }) => (
   <h1>Hello world! - user agent: {userAgent}</h1>
 );
 


### PR DESCRIPTION
Without the `?`, the editor complains that 
```
Type '({ req }: NextPageContext) => Promise<{ userAgent: string | undefined; }>' is not assignable to type '(ctx: NextPageContext) => Promise<{ userAgent: string; }>'.
```