### PR TITLE
Should be changed to public folder

### DIFF
--- a/pages/learn/basics/using-shared-components/the-component-directory.mdx
+++ b/pages/learn/basics/using-shared-components/the-component-directory.mdx
@@ -11,7 +11,7 @@ export const meta = {
 
 Yes. It will work as expected.
 
-We don't need to put our components in a special directory; the directory can be named anything. The only special directories are `/pages` and `/static`.
+We don't need to put our components in a special directory; the directory can be named anything. The only special directories are `/pages` and `/public`.
 
 You can even create the Component inside the `pages` directory.
 


### PR DESCRIPTION
https://nextjs.org/blog/next-9-1#public-directory-support

> Because public also covers the static directory use case we have decided to deprecate the static directory in favor of creating a public/static folder with the same functionality