### PR TITLE
Fixed overflow on showcase projects @ desktop

### DIFF
--- a/components/home/showcase-preview.js
+++ b/components/home/showcase-preview.js
@@ -79,6 +79,7 @@ export default () => {
           .showcase-container.desktop {
             display: none;
             margin: 4rem auto 2rem auto;
+            overflow-x: hidden;
           }
           .slides {
             display: flex;


### PR DESCRIPTION
Got this issue from [here](https://github.com/zeit/next-site/issues/508): 

Adding an overflow: hidden to the project carousel eliminates the gap and horizontal scrolling doesn’t happen anymore.

  Tested on Firefox 72.0, Chrome 79 and Safari 13.0.4  

Let me know what you think!