### PR TITLE
Add foreground color to dark pre tags

### DIFF
--- a/components/blog/post-components.js
+++ b/components/blog/post-components.js
@@ -48,6 +48,7 @@ const Code = ({ children, syntax }) => {
         {`
           pre {
             background: #1d1f21;
+            color: #f8f8f2;
             white-space: pre;
             overflow: auto;
             padding: 1.5rem;

--- a/components/docs/docs-page.js
+++ b/components/docs/docs-page.js
@@ -116,6 +116,7 @@ function DocsPage({ path, html }) {
         /* Code */
         .docs pre {
           background: #1d1f21;
+          color: #f8f8f2;
           white-space: pre;
           overflow: auto;
           padding: 1.5rem;

--- a/components/docs/text/code.js
+++ b/components/docs/text/code.js
@@ -5,6 +5,7 @@ export const Code = ({ children, syntax }) => (
       {`
         pre {
           background: #1d1f21;
+          color: #f8f8f2;
           white-space: pre;
           overflow: auto;
           padding: 1.5rem;

--- a/components/learn/Markdown.js
+++ b/components/learn/Markdown.js
@@ -65,6 +65,7 @@ const Code = ({ children }) => (
     <style jsx>{`
       pre {
         background: #1d1f21;
+        color: #f8f8f2;
         white-space: pre;
         overflow: auto;
         padding: 1.5rem;


### PR DESCRIPTION
## Problem

[On this blog post](https://nextjs.org/blog/next-9), the code block following the text "meaning the following examples work:" appears blank.

<img width="710" alt="Screen Shot 2020-01-11 at 12 02 02 AM" src="https://user-images.githubusercontent.com/992008/72201111-99eabc80-3405-11ea-8c90-2a396838114a.png">

This is because this particular code snippet doesn't specify the language for syntax highlighting:

<pre>
```
next build
next export
```
</pre>

And if you don't specify a language, then `language-` class doesn't get added, and [this global CSS (`pre[class*='language-']`)](https://github.com/chibicode/next-site/blob/8446e1d148e432655c3fd443c84ae67b9154e4bc/components/page.js#L235-L247) which sets `color: #f8f8f2` will not be applied.

This is currently an issue for the following pages:

- https://nextjs.org/docs/old#usage
- https://nextjs.org/blog/next-5#improved-caching-for-dynamic-imports
- https://nextjs.org/blog/next-6#nested-babelrc
- https://nextjs.org/blog/next-7#static-cdn-support
- https://nextjs.org/blog/next-8-1#learn-to-use-amp-with-nextjs
- https://nextjs.org/blog/next-9#dynamic-route-segments
- https://nextjs.org/learn/excel/lazy-loading-modules/its-own-bundle

## Solution

This can be fixed in one of three ways:

1. Change global CSS from `pre[class*='language-']` to `pre`: I didn't choose this because we might want to use `pre` for something else, and I generally try to avoid touching global CSS
2. Make sure every code snippet has some language associated with it: While most snippets can be set as `bash`, sometimes you'd just want to use plain text. However, Prism doesn't have plain text as an option.
3. Change component-scoped CSS for `pre` tags that have a dark background: This is the approach I chose.

Fixed pages:

- https://next-site-git-fork-chibicode-fix-dark-pre-tags.zeit.now.sh/docs/old#usage
- https://next-site-git-fork-chibicode-fix-dark-pre-tags.zeit.now.sh/blog/next-5#improved-caching-for-dynamic-imports
- https://next-site-git-fork-chibicode-fix-dark-pre-tags.zeit.now.sh/blog/next-6#nested-babelrc
- https://next-site-git-fork-chibicode-fix-dark-pre-tags.zeit.now.sh/blog/next-7#static-cdn-support
- https://next-site-git-fork-chibicode-fix-dark-pre-tags.zeit.now.sh/blog/next-8-1#learn-to-use-amp-with-nextjs
- https://next-site-git-fork-chibicode-fix-dark-pre-tags.zeit.now.sh/blog/next-9#dynamic-route-segments
- https://next-site-git-fork-chibicode-fix-dark-pre-tags.zeit.now.sh/learn/excel/lazy-loading-modules/its-own-bundle