### PR TITLE
Improve AnswerBox widget on /learn/*

### DIFF
--- a/components/learn/AnswerBox.js
+++ b/components/learn/AnswerBox.js
@@ -95,10 +95,18 @@ const Symbol = ({ correct, selected }) => {
   );
 };
 
-const AnswerResultMessage = ({ correct }) => (
+const AnswerResultMessage = ({ answer, correctAnswer }) => (
   <>
-    <Symbol correct={correct} selected />{' '}
-    {correct ? (
+    {typeof answer !== 'undefined' && (
+      <>
+        <Symbol correct={answer === correctAnswer} selected />{' '}
+      </>
+    )}
+    {typeof answer === 'undefined' ? (
+      <>
+        The correct answer is: <strong>{correctAnswer}</strong>.
+      </>
+    ) : answer === correctAnswer ? (
       <span className="correct-message">
         <strong>Correct.</strong> Good job!
       </span>
@@ -137,7 +145,7 @@ const AnswerBox = ({ answers, correctAnswer, record, dispatchRecord }) => (
     ))}
     <div>
       {record.submitted ? (
-        <AnswerResultMessage correct={record.answer === correctAnswer} />
+        <AnswerResultMessage answer={record.answer} correctAnswer={correctAnswer} />
       ) : (
         <Button
           onClick={() => {

--- a/components/learn/AnswerBox.js
+++ b/components/learn/AnswerBox.js
@@ -82,7 +82,7 @@ const Symbol = ({ correct, selected }) => {
 
   return (
     <span>
-      {correct ? <CheckIcon color="#19ce56" /> : <CrossIcon color="red" />}
+      {correct ? <CheckIcon color="#0070f3" /> : <CrossIcon color="#e00" />}
       <style jsx>{`
         span {
           display: inline-block;
@@ -94,6 +94,30 @@ const Symbol = ({ correct, selected }) => {
     </span>
   );
 };
+
+const AnswerResultMessage = ({ correct }) => (
+  <>
+    <Symbol correct={correct} selected />{' '}
+    {correct ? (
+      <span className="correct-message">
+        <strong>Correct.</strong> Good job!
+      </span>
+    ) : (
+      <span className="incorrect-message">
+        <strong>Incorrect,</strong> but nice try!
+      </span>
+    )}
+    <style jsx>{`
+      .correct-message {
+        color: #0070f3;
+      }
+
+      .incorrect-message {
+        color: #e00;
+      }
+    `}</style>
+  </>
+);
 
 const AnswerBox = ({ answers, correctAnswer, record, dispatchRecord }) => (
   <Area>
@@ -111,8 +135,10 @@ const AnswerBox = ({ answers, correctAnswer, record, dispatchRecord }) => (
         )}
       </Answer>
     ))}
-    {!record.submitted && (
-      <div>
+    <div>
+      {record.submitted ? (
+        <AnswerResultMessage correct={record.answer === correctAnswer} />
+      ) : (
         <Button
           onClick={() => {
             dispatchRecord({ type: 'submit' });
@@ -126,13 +152,13 @@ const AnswerBox = ({ answers, correctAnswer, record, dispatchRecord }) => (
         >
           Submit
         </Button>
-        <style jsx>{`
-          div {
-            margin: 2rem 0 4rem;
-          }
-        `}</style>
-      </div>
-    )}
+      )}
+      <style jsx>{`
+        div {
+          margin: 2rem 0 4rem;
+        }
+      `}</style>
+    </div>
   </Area>
 );
 

--- a/components/learn/AnswerBox.js
+++ b/components/learn/AnswerBox.js
@@ -86,9 +86,9 @@ const Symbol = ({ correct, selected }) => {
       <style jsx>{`
         span {
           display: inline-block;
-          lineheight: 1;
-          verticalalign: middle;
-          marginleft: 0.25rem;
+          line-height: 1;
+          vertical-align: middle;
+          margin-left: 0.25rem;
         }
       `}</style>
     </span>

--- a/components/learn/AnswerBox.js
+++ b/components/learn/AnswerBox.js
@@ -104,7 +104,7 @@ const AnswerResultMessage = ({ answer, correctAnswer }) => (
     )}
     {typeof answer === 'undefined' ? (
       <>
-        The correct answer is: <strong>{correctAnswer}</strong>.
+        The correct answer is: <strong>{correctAnswer}</strong>
       </>
     ) : answer === correctAnswer ? (
       <span className="correct-message">

--- a/components/learn/Navigation.js
+++ b/components/learn/Navigation.js
@@ -35,7 +35,7 @@ const Lesson = ({ course, lesson, selected }) => {
       <Link href={`/learn/${course.id}/${lesson.id}`}>
         <a className={classNames('f5', { fw7: selected, selected, finished })}>
           <span className="step" title={`${finishedSteps} / ${totalSteps} finished`}>
-            {finished && <CheckIcon color="#2BDB66" />}
+            {finished && <CheckIcon color="#0070F3" />}
           </span>
           <span className="label">{lesson.name}</span>
         </a>


### PR DESCRIPTION
I made some improvements to the AnswerBox widget (quiz UI) on Learn pages.

- **Fixed CSS typos** (`lineheight` → `line-height`, etc)
- **Updated icon colors:** We were using green checkbox icons for this widget, but according to [zeit.co/design/color](https://zeit.co/design/color), we don't use green for success state (probably for accessibility reasons). It now uses default success/error colors (`--geist-success` and `--geist-error`) for check/cross icons. Also: the other place that was using green icons was the side navigation. I updated the icons here as well.

### Before (Quiz)

<img width="286" alt="Screen Shot 2020-01-11 at 3 44 52 PM" src="https://user-images.githubusercontent.com/992008/72211984-533ea600-3489-11ea-8cae-77ab516dde7e.png">

### After (Quiz)

<img width="287" alt="Screen Shot 2020-01-11 at 3 45 16 PM" src="https://user-images.githubusercontent.com/992008/72211989-5e91d180-3489-11ea-909e-c53eaaf248e7.png">

### Before (Side Nav)

<img width="253" alt="Screen Shot 2020-01-11 at 3 43 54 PM" src="https://user-images.githubusercontent.com/992008/72211977-3013f680-3489-11ea-9966-76be868ed64b.png">

### After (Side Nav)

<img width="247" alt="Screen Shot 2020-01-11 at 3 42 48 PM" src="https://user-images.githubusercontent.com/992008/72211972-238f9e00-3489-11ea-86fe-e90264155f06.png">

---

- **Added a friendly result message**. Before it didn't show any message - it was just icons. I thought adding a friendly message would add a nice touch.

### Correct

<img width="626" alt="Screen Shot 2020-01-11 at 3 23 16 PM" src="https://user-images.githubusercontent.com/992008/72211860-5f296880-3487-11ea-9536-0c93195a620d.png">

### Incorrect

<img width="627" alt="Screen Shot 2020-01-11 at 3 23 21 PM" src="https://user-images.githubusercontent.com/992008/72211863-66507680-3487-11ea-9927-f9c0a10d3d27.png">

### Not selected

<img width="633" alt="Screen Shot 2020-01-12 at 9 56 29 PM" src="https://user-images.githubusercontent.com/992008/72235339-74d18780-3586-11ea-9247-a69b85ee8bad.png">
