### PR TITLE
Wordsmith "Link is just a..." page

### DIFF
--- a/lib/learn/courses.js
+++ b/lib/learn/courses.js
@@ -50,7 +50,7 @@ const courses = [
             points: 15
           },
           {
-            id: 'hoc',
+            id: 'link',
             points: 5
           },
           {

--- a/next.config.js
+++ b/next.config.js
@@ -73,6 +73,11 @@ const nextConfig = {
           destination: '/learn/excel/automatic-static-optimization'
         },
         {
+          source: '/learn/basics/navigate-between-pages/hoc{/}?',
+          statusCode: 301,
+          destination: '/learn/basics/navigate-between-pages/link'
+        },
+        {
           source: '/features{/}?',
           statusCode: 301,
           destination: '/features/static-exporting'

--- a/pages/learn/basics/navigate-between-pages/hoc.mdx
+++ b/pages/learn/basics/navigate-between-pages/hoc.mdx
@@ -7,10 +7,8 @@ export const meta = {
   stepId: 'hoc'
 };
 
-## Link is Just a Higher Order Component (HOC)
+## Link is Just a Wrapper Component
 
-Actually, the title prop on `next/link` component has no effect. That's because `next/link` is just a [higher order component](https://reactjs.org/docs/higher-order-components.html) which only accepts the `href` and some similar props. If you need to add props to it, you need to do it to the underlying component. Do not expect the `next/link` component to pass those props to its children.
-
-In this case, the child of the `next/link` component is the anchor tag. It can also work with any other component or tag, the only requirement for components placed inside `<Link />` is that they should accept an `onClick` prop.
+Actually, the title prop on the `Link` component has no effect. That's because `Link` is just a wrapper component which only accepts `href` and some similar props. If you need to add props to it, you need to add them to its child. In this case, the child of the `Link` component is the anchor tag.
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/basics/navigate-between-pages/link.mdx
+++ b/pages/learn/basics/navigate-between-pages/link.mdx
@@ -4,7 +4,7 @@ export const meta = {
   title: 'Navigate Between Pages',
   courseId: 'basics',
   lessonId: 'navigate-between-pages',
-  stepId: 'hoc'
+  stepId: 'link'
 };
 
 ## Link is Just a Wrapper Component


### PR DESCRIPTION
- Fixes https://github.com/zeit/next-site/issues/200
- Made some more edits.

**Before:** https://nextjs.org/learn/basics/navigate-between-pages/hoc 
**After:** https://next-site-git-fork-chibicode-link-wrapper-component.zeit.now.sh/learn/basics/navigate-between-pages/hoc

## Edit Notes

- **`next/link` → `Link`:** It matches with the page title ("Link is...") and simpler.
- **"the `href`" → `href`**
- **"do it to the underlying component" → "add them to its child":** Since it's a wrapper component, "child" makes more sense.
- **Removed "Do not expect...":** This sentence doesn't add much value. It'll be simpler if removed.
- **Removed "It can also work with any other component or tag, the only requirement...":** First, this description is incorrect - [according to the documentation](https://nextjs.org/docs/api-reference/next/link#using-a-component-that-supports-onclick), the child needs to support `onClick` EVENT and not prop. Second, I think this specific use case (use a non-anchor child) is not often used and it probably confuses the reader (they might think, "when would I not use an anchor tag?"). I think it's more reader-friendly if removed.

## Other Notes

The page's URL ends with `hoc`, which is no longer accurate, but I didn't change the filename to preserve the URL. Let me know if you think the URL should be changed to something else.