### PR TITLE
Fix grammar errors for /learn/*

### DIFF
--- a/pages/learn/basics/api-routes/fetching-api-routes.mdx
+++ b/pages/learn/basics/api-routes/fetching-api-routes.mdx
@@ -24,7 +24,7 @@ export default (req, res) => {
 };
 ```
 
-And now let's consume our API and display the random quote in a page.
+And now let's consume our API and display a random quote in a page.
 
 Open `pages/index.js` and replace its content with the following:
 
@@ -76,6 +76,6 @@ export default function Index() {
 
 In your browser, open http://localhost:3000 and you'll be able to see a random quote from the API, and you can refresh the page to update the quote.
 
-We're using a package called [SWR](https://github.com/zeit/swr) to fetch our API, it's a React Hook for remote data fetching. You can learn more about it [here](https://swr.now.sh/).
+We're using a package called [SWR](https://github.com/zeit/swr) to fetch our API. It's a React Hook for remote data fetching. You can learn more about it [here](https://swr.now.sh/).
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/basics/clean-urls-with-dynamic-routing/dynamic-routing.mdx
+++ b/pages/learn/basics/clean-urls-with-dynamic-routing/dynamic-routing.mdx
@@ -19,9 +19,9 @@ export const meta = {
 
 ## Dynamic Routing
 
-Here, we are going to use the [Dynamic Routing](https://nextjs.org/docs#dynamic-routing) feature of Next.js, it allows you to handle dynamic routes in `/pages`.
+Here, we are going to use the [Dynamic Routing](https://nextjs.org/docs#dynamic-routing) feature of Next.js. It allows you to handle dynamic routes in `/pages`.
 
-Let's create our first dynamic route by adding a new page to `pages/p/[id].js`, notice that you need to add the folder `/p` inside `/pages` first, and that the page is called `[id].js`. Then add the following content:
+Let's create our first dynamic route by adding a new page to `pages/p/[id].js`. Notice that you need to add the folder `/p` inside `/pages` first, and that the page is called `[id].js`. Then add the following content:
 
 ```jsx
 import { useRouter } from 'next/router';
@@ -39,9 +39,9 @@ export default function Post() {
 }
 ```
 
-The previous page is special, instead of handling a static route like `/about`, it will handle routes that come after `/p/`. For example, `/p/hello-nextjs` will be handled by this page. Although, `/p/post-1/another` will not.
+This page is special. Instead of handling a static route like `/about`, it will handle routes that come after `/p/`. For example, `/p/hello-nextjs` will be handled by this page. It will not handle routes like `/p/post-1/another` though.
 
-Having brackets (`[]`) in the page name makes it a dynamic route. Currently, you can not make part of a page name dynamic, only the full name. For example, `/pages/p/[id].js` is supported but `/pages/p/post-[id].js` is not currently.
+Having brackets (`[]`) in the page name makes it a dynamic route. Currently, you can not make part of a page name dynamic. For example, `/pages/p/[id].js` is supported but `/pages/p/post-[id].js` won’t work.
 
 When creating the dynamic route we added `id` between the brackets (`[]`). This is the name of the query param received by the page, so for `/p/hello-nextjs` the `query` object will have `{ id: 'hello-nextjs'}`, and we can access it with [useRouter()](https://nextjs.org/docs#userouter).
 

--- a/pages/learn/basics/clean-urls-with-dynamic-routing/finally.mdx
+++ b/pages/learn/basics/clean-urls-with-dynamic-routing/finally.mdx
@@ -9,7 +9,7 @@ export const meta = {
 
 ## Finally
 
-That's the end of this lesson, if you want to know more about dynamic routing check out the [dynamic-routing example](https://github.com/zeit/next.js/tree/canary/examples/dynamic-routing) in the Next.js repo and the [documentation](https://nextjs.org/docs#dynamic-routing).
+That's the end of this lesson, if you want to know more about dynamic routing, check out the [dynamic-routing example](https://github.com/zeit/next.js/tree/canary/examples/dynamic-routing) in the Next.js repo and the [documentation](https://nextjs.org/docs#dynamic-routing).
 
 Our next lesson is about dynamic data fetching. Let's add some data now.
 

--- a/pages/learn/basics/styling-components/global-styles-work.mdx
+++ b/pages/learn/basics/styling-components/global-styles-work.mdx
@@ -11,7 +11,7 @@ export const meta = {
 
 Yep that worked well. It worked, because our styles applied globally.
 
-While this feature can be incredibly handy, we always recommend trying to write scoped styles (without the global prop).
+While this feature can be incredibly handy, we recommend writing scoped styles whenever possible.
 
 Still, this is a great solution over normal style tags. With styled-jsx all necessary prefixing and CSS validation is done inside a babel plugin, so there is no additional runtime overhead.
 

--- a/pages/learn/basics/styling-components/index.mdx
+++ b/pages/learn/basics/styling-components/index.mdx
@@ -11,15 +11,13 @@ Until now, styling components was largely an afterthought. But your app deserves
 For a React app, there are many different techniques that we can use to style it, and those can be categorized into two broad methods:
 
 1. Traditional CSS-file-based styling (including SASS, PostCSS etc)
-2. [CSS in Js](https://github.com/MicheleBertoli/css-in-js) styling
+2. [CSS in JS](https://github.com/MicheleBertoli/css-in-js) styling
 
 Consequently, there are a bunch of practical issues to consider with traditional CSS-file-based styling (especially with SSR), so we suggest avoiding this method when styling for Next.js.
 
 Instead we recommend CSS in JS, which you can use to style individual components rather than importing CSS files.
 
-Next.js comes preloaded with a CSS in JS framework called [styled-jsx](https://github.com/zeit/styled-jsx), specifically designed to make your life easier. It allows you to write familiar CSS rules for your components; rules will have no impact on anything other than the components (not even child components).
-
-> That means, your CSS rules are scoped.
+Next.js comes preloaded with a CSS in JS framework called [styled-jsx](https://github.com/zeit/styled-jsx), specifically designed to make your life easier. It allows you to write familiar CSS rules for your components. Your CSS rules are component-scoped, which means that the rules will have no impact on other components (not even child components).
 
 Let's see how we can use styled-jsx.
 

--- a/pages/learn/basics/styling-components/what-next.mdx
+++ b/pages/learn/basics/styling-components/what-next.mdx
@@ -7,7 +7,7 @@ export const meta = {
   stepId: 'what-next'
 };
 
-## What Next
+## What’s Next
 
 We have just scratched the surface with styled-jsx here, and there is a lot more that you can do. Refer to the [styled-jsx](https://github.com/zeit/styled-jsx) GitHub repo for more info.
 

--- a/pages/learn/basics/using-shared-components/the-component-directory.mdx
+++ b/pages/learn/basics/using-shared-components/the-component-directory.mdx
@@ -13,8 +13,4 @@ Yes. It will work as expected.
 
 We don't need to put our components in a special directory; the directory can be named anything. The only special directories are `/pages` and `/public`.
 
-You can even create the Component inside the `pages` directory.
-
-Here we didn't do that because we don't need a direct URL to our Header component.
-
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/automatic-static-optimization/serverless.mdx
+++ b/pages/learn/excel/automatic-static-optimization/serverless.mdx
@@ -23,7 +23,7 @@ We can have static and SSR pages in the same app by only using `next build`.
 
 Static HTML should always be fast since it can be cached very well, although there are still cases where you need to handle dynamic data. For these cases you can create lambda functions for each page.
 
-We don't need a server if we can create a lambda per page, pages are independent after all, let's add the file `next.config.js` in the root folder with the following content:
+We don't need a server if we can create a lambda per page. Our pages are independent after all. Let's add the file `next.config.js` in the root folder with the following content:
 
 ```jsx
 module.exports = {

--- a/pages/learn/excel/static-html-export/exporting-other-pages.mdx
+++ b/pages/learn/excel/static-html-export/exporting-other-pages.mdx
@@ -50,9 +50,9 @@ As is shown in the above config, the `/about` path is very similar to the `/` pa
 
 Here's what's going on:
 
-To render the shows in our app, we first fetch the list of shows, this is the same fetch we do in `/`. We then loop the shows and add a new path and query for every one of them.
+To render the shows in our app, we first fetch the list of shows. This is the same fetch we do in `/`. We then loop the shows and add a new path for each show.
 
-For example for the show of `Batman` with the id `975` the loop will add the following path:
+For example, for the show `Batman` (id `975`) the loop will add the following path:
 
 ```js
 '/show/975': { page: '/show/[id]', query: { id: '975' } }
@@ -60,7 +60,7 @@ For example for the show of `Batman` with the id `975` the loop will add the fol
 
 The page `/show/[id]` will then use the `query` object to get the `id` and fetch more info about the show.
 
-Now close the existing app running with serve and run the following commands in the root folder:
+Now close the existing app running with `serve` and run the following commands in the root folder:
 
 ```bash
 npm run export

--- a/pages/learn/excel/static-html-export/index.mdx
+++ b/pages/learn/excel/static-html-export/index.mdx
@@ -11,7 +11,7 @@ The best way to deploy your web app is as a static HTML app, if that's possible.
 But not every app can be deployed as a static app. If your app needs to generate dynamic pages at the runtime, you can't deploy it as a static app.
 
 If you can categorize your app as a static app, you can build it with Next.js.
-Next.js 3.0 comes with a feature that allows you to export an app into a set of HTML pages.
+Next.js comes with a feature that allows you to export an app into a set of HTML pages.
 
 In this lesson, we are going to explore that feature.
 Let's get started.

--- a/pages/learn/excel/static-html-export/setup.mdx
+++ b/pages/learn/excel/static-html-export/setup.mdx
@@ -25,6 +25,6 @@ npm run dev
 
 Now you can access the app by navigating to http://localhost:3000/.
 
-> The example uses [Dynamic Routing](https://nextjs.org/docs#dynamic-routing), you may want to check the [Create Dynamic Pages lesson](https://nextjs.org/learn/basics/create-dynamic-pages) first.
+> The example uses [Dynamic Routing](https://nextjs.org/docs#dynamic-routing). You may want to check the [Create Dynamic Pages lesson](https://nextjs.org/learn/basics/create-dynamic-pages) first.
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/static-html-export/thats-it.mdx
+++ b/pages/learn/excel/static-html-export/thats-it.mdx
@@ -9,9 +9,6 @@ export const meta = {
 
 ## That's It
 
-This is all about the [static HTML export](https://nextjs.org/docs#static-html-export) feature of Next.js. You can develop your app, usually with `next` (AKA: `npm run dev`), and when it's time to deploy the app, you can export it as a static app.
-
-But if you need to create pages dynamically after you've deploy the app, this is not the solution.
-For that, you need to build the app and start it with `next start`
+That’s all for the [static HTML export](https://nextjs.org/docs#static-html-export) feature of Next.js. You can run `npm run dev` while developing your app, and when it's time to deploy the app, you can export it as a static app.
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;


### PR DESCRIPTION
**Draft PR:** I noticed some grammar errors in `/learn/*` - slowly fixing one by one. Many are related to [run-on sentences](https://academicguides.waldenu.edu/writingcenter/grammar/runonsentences).

---

## Other issues I noticed

### "Using Shared Components"

- On "[Rendering Child Components](https://nextjs.org/learn/basics/using-shared-components/rendering-children-components)" - do we really need "Layout as a Higher Order Component" or "Page content as a prop"? This is probably the domain of a React tutorial and not a Next.js tutorial.

### "Styling Components"

- On "[No Effect for Nested Component](https://nextjs.org/learn/basics/styling-components/no-effect-for-nested-components)", "Otherwise, you could use global selectors" at the bottom seems very out-of-context.
- On "[Global Styles](https://nextjs.org/learn/basics/styling-components/global-styles)", it uses `react-markdown`, but why not use MDX? MDX seems like an easier way for people to use markdown in Next.js because it has an official plugin. Of course, this will make the example obsolete (since you don't need to rely on global styles for MDX).

### "Export into a Static HTML App"

- [No need to always rebuild](https://nextjs.org/learn/excel/static-html-export/no-need-to-build-always) seems like a minor detail that can be skipped. I think we should be recommending `build` script to do both `build` and `export`, i.e. `build: next build && next export`. [This will enable zero-config deploy to Now](https://nextjs.org/blog/next-9-1-7). However, this might make "[Deploying App](https://nextjs.org/learn/excel/static-html-export/deploying-the-app)" obsolete (you don't need to `cd out`).