### PR TITLE
Fix: Wrong TOC anchor link in v9.2 docs

### DIFF
--- a/blog/next-9-2-preview.mdx
+++ b/blog/next-9-2-preview.mdx
@@ -31,6 +31,6 @@ export const meta = {
 We are excited today to introduce the production-ready Next.js 9.2, featuring:
 
 - [Built-In CSS Support for Global Stylesheets](#built-in-css-support-for-global-stylesheets)
-- [Built-In CSS Module Support for Component-Level Styles](#built-in-css-support-for-global-stylesheets)
+- [Built-In CSS Module Support for Component-Level Styles](#built-in-css-module-support-for-component-level-styles)
 - [Improved Code-Splitting Strategy](#improved-code-splitting-strategy)
 - [Catch-All Dynamic Routes](#catch-all-dynamic-routes)

--- a/pages/blog/next-9-2.mdx
+++ b/pages/blog/next-9-2.mdx
@@ -11,7 +11,7 @@ export default withPost({ ...meta })
 We are excited today to introduce Next.js 9.2, featuring:
 
 - **[Built-In CSS Support for Global Stylesheets](#built-in-css-support-for-global-stylesheets)**: Applications can now directly import `.css` files as global stylesheets.
-- **[Built-In CSS Module Support for Component-Level Styles](#built-in-css-support-for-global-stylesheets)**: Leveraging the `.module.css` convention, locally scoped CSS can be imported and used anywhere in your application.
+- **[Built-In CSS Module Support for Component-Level Styles](#built-in-css-module-support-for-component-level-styles)**: Leveraging the `.module.css` convention, locally scoped CSS can be imported and used anywhere in your application.
 - **[Improved Code-Splitting Strategy](#improved-code-splitting-strategy)**: The Google Chrome team heavily optimized Next.js' code-splitting strategy, resulting in significantly smaller client-side bundles. Furthermore, they've maximized [HTTP/2](https://developers.google.com/web/fundamentals/performance/http2) utilization to improve page load speed without hurting HTTP/1.1 performance.
 - **[Catch-All Dynamic Routes](#catch-all-dynamic-routes)**: Next.js' Dynamic Routes now support catch-all routes, supporting a variety of new use-cases, e.g. CMS-powered websites.
 


### PR DESCRIPTION
Fix: Wrong TOC anchor link in v9.2 docs