### PR TITLE
Use https : learn/basics/fetching-data-for-pages

### DIFF
--- a/pages/learn/basics/fetching-data-for-pages/fetching-batman-shows.mdx
+++ b/pages/learn/basics/fetching-data-for-pages/fetching-batman-shows.mdx
@@ -22,7 +22,7 @@ export const meta = {
 In our demo app, we have a list of blog posts on the home page. Now we are going to display a list of Batman TV shows.
 Instead of hardcoding those shows, we are going to fetch them from a remote server.
 
-> Here we are using the [TVMaze API](http://www.tvmaze.com/api) to fetch those TV shows.
+> Here we are using the [TVMaze API](https://www.tvmaze.com/api) to fetch those TV shows.
 > It's an API to search for TV shows information.
 
 First of all we need to install [isomorphic-unfetch](https://github.com/developit/unfetch). That's the library we are going to use to fetch data. It's a simple implementation of the browser [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) API, but works both in client and server environments.

--- a/pages/learn/basics/fetching-data-for-pages/index.mdx
+++ b/pages/learn/basics/fetching-data-for-pages/index.mdx
@@ -14,7 +14,7 @@ In practice, we usually need to fetch data from a remote data source. Next.js co
 
 With `getInitialProps`, we can fetch data for a given page via a remote data source and pass it as props to our page. `getInitialProps` needs to work on both server and client; since it is called in both environments.
 
-In this lesson, using `getInitialProps`, we are going to build an app which shows information about Batman TV Shows, utilising the public [TVmaze API](http://www.tvmaze.com/api).
+In this lesson, using `getInitialProps`, we are going to build an app which shows information about Batman TV Shows, utilising the public [TVmaze API](https://www.tvmaze.com/api).
 
 ![](https://cloud.githubusercontent.com/assets/50838/26300776/bbf275ee-3efc-11e7-8304-df96c7c7cad5.png)
 


### PR DESCRIPTION
Hi, thank you for awesome tutorial 👍

# What

Some URL of `TVmaze API` are still used by `http`, see below.

```
pages/learn/basics/fetching-data-for-pages/index.mdx:In this lesson, using `getInitialProps`, we are going to build an app which shows information about Batman TV Shows, utilising the public [TVmaze API](http://www.tvmaze.com/api).
pages/learn/basics/fetching-data-for-pages/fetching-batman-shows.mdx:> Here we are using the [TVMaze API](http://www.tvmaze.com/api) to fetch those TV shows.
pages/learn/basics/fetching-data-for-pages/fetching-batman-shows.mdx:  const res = await fetch('https://api.tvmaze.com/search/shows?q=batman');
pages/learn/basics/fetching-data-for-pages/fetching-batman-shows.mdx:  const res = await fetch('https://api.tvmaze.com/search/shows?q=batman');
pages/learn/basics/fetching-data-for-pages/fetching-data-for-pages.mdx:  const res = await fetch(`https://api.tvmaze.com/shows/${id}`);
pages/learn/basics/fetching-data-for-pages/fetching-data-for-pages.mdx:  const res = await fetch(`https://api.tvmaze.com/shows/${id}`);
pages/learn/excel/static-html-export/exporting-other-pages.mdx:    const res = await fetch('https://api.tvmaze.com/search/shows?q=batman');
```

So, I updated URL.

- From
    - http://www.tvmaze.com/api
- To
    - https://www.tvmaze.com/api

Thanks.