### PR TITLE
Fix home showcase gradient

### DIFF
--- a/components/home/showcase-preview.js
+++ b/components/home/showcase-preview.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useAmp } from 'next/amp';
 import { sortedByAlexa } from '../../showcase-manifest';
-import Image from './../image';
+import Image from '../image';
 
 // length should be odd numbers
 const DATA = sortedByAlexa.slice(0, 7);
@@ -42,7 +42,12 @@ export default () => {
             right: 0;
             z-index: 2;
             bottom: -2rem;
-            background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 30%, #f6f6f6 85%);
+            background: linear-gradient(
+              to bottom,
+              rgba(250, 250, 250, 0) 30%,
+              rgba(250, 250, 250, 0.7) 90%,
+              rgba(250, 250, 250, 1) 100%
+            );
           }
           @media screen and (max-width: 640px) {
             .slide {


### PR DESCRIPTION
On the home page showcase / customer section, the current `linear-gradient` was too strong and it was making the last screenshot disappear. I made it a bit more visible.

# Before

<img src="https://user-images.githubusercontent.com/992008/73796396-e950ae00-4761-11ea-9ace-f56041d25fef.png" width="467" height="739" />

---

![localhost_3000_ (2)](https://user-images.githubusercontent.com/992008/73796401-ec4b9e80-4761-11ea-8ee3-5e8a6b08a002.png)


# After

<img src="https://user-images.githubusercontent.com/992008/73796455-14d39880-4762-11ea-8359-7dbfc33d2c94.png" width="417" height="739" />

![localhost_3000_ (5)](https://user-images.githubusercontent.com/992008/73796462-1a30e300-4762-11ea-82ab-90bef71326dd.png)
