### PR TITLE
Make the auto scroll in docs more consistent

### DIFF
--- a/components/sidebar/category.js
+++ b/components/sidebar/category.js
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect } from 'react';
 import cn from 'classnames';
 import ArrowRightSidebar from '../icons/arrow-right-sidebar';
 
-export default function Category({ level = 1, title, selected, opened, children }) {
+export default function Category({ isMobile, level = 1, title, selected, opened, children }) {
   const ref = useRef();
   const [{ toggle, shouldScroll = false }, setToggle] = useState({ toggle: selected || opened });
   const toggleCategory = () => {
@@ -20,10 +20,14 @@ export default function Category({ level = 1, title, selected, opened, children 
   // Navigate to the start of the category when manually opened
   useEffect(() => {
     if (toggle && shouldScroll) {
-      ref.current.scrollIntoView();
+      const content = document.querySelector(isMobile ? '.docs-dropdown' : '.sidebar-content');
+      // 10 is added for better margin
+      const height = ref.current.offsetTop - (isMobile ? 10 : content.offsetTop);
+
+      content.scrollTop = height;
       setToggle({ toggle });
     }
-  }, [toggle, shouldScroll]);
+  }, [toggle, shouldScroll, isMobile]);
 
   return (
     <div ref={ref} className={cn('category', levelClass, { open: toggle, selected })}>
@@ -33,6 +37,15 @@ export default function Category({ level = 1, title, selected, opened, children 
       </a>
       <div className="posts">{children}</div>
       <style jsx>{`
+        .category {
+          margin: 18px 0;
+        }
+        .category:first-child {
+          margin-top: 0;
+        }
+        .category:last-child {
+          margin-bottom: 0;
+        }
         .label {
           font-size: 1rem;
           line-height: 1.5rem;
@@ -65,15 +78,6 @@ export default function Category({ level = 1, title, selected, opened, children 
         .label:hover {
           color: #000;
         }
-        .category {
-          margin: 18px 0;
-        }
-        .category:first-child {
-          margin-top: 0;
-        }
-        .category:last-child {
-          margin-bottom: 0;
-        }
         .separated {
           margin-bottom: 32px;
         }
@@ -83,7 +87,7 @@ export default function Category({ level = 1, title, selected, opened, children 
           height: 0;
           overflow: hidden;
           padding-left: 19px;
-          margin-left: 4px;
+          margin-left: 3px;
         }
         .open > .posts {
           margin-top: 18px;

--- a/components/sidebar/heading.js
+++ b/components/sidebar/heading.js
@@ -2,15 +2,12 @@ export default function Heading({ title, children }) {
   return (
     <div className="heading">
       <h4>{title}</h4>
-      <div className="posts">{children}</div>
+      <div>{children}</div>
       <style jsx>{`
         h4 {
           margin: 1.25rem 0;
           font-size: 1.2rem;
           font-weight: 600;
-        }
-        .posts {
-          margin-left: 4px;
         }
       `}</style>
     </div>

--- a/components/sidebar/post.js
+++ b/components/sidebar/post.js
@@ -8,9 +8,13 @@ export default function Post({ isMobile, route, level = 1, onClick, ...props }) 
 
   useEffect(() => {
     if (ref && ref.current && !isMobile) {
-      ref.current.scrollIntoView({ block: 'center' });
+      const content = document.querySelector('.sidebar-content');
+      // 32 is the top and bottom margin for .link
+      const height = ref.current.offsetTop - 32;
+
+      content.scrollTop = height - content.offsetHeight / 2;
     }
-  }, [ref]);
+  }, [ref, isMobile]);
 
   return (
     <div ref={ref} className={cn('link', `level-${level}`)}>

--- a/components/sidebar/post.js
+++ b/components/sidebar/post.js
@@ -9,7 +9,7 @@ export default function Post({ isMobile, route, level = 1, onClick, ...props }) 
   useEffect(() => {
     if (ref && ref.current && !isMobile) {
       const content = document.querySelector('.sidebar-content');
-      // 32 is the top and bottom margin for .link
+      // 32 is the top and bottom margin for `.link`
       const height = ref.current.offsetTop - 32;
 
       content.scrollTop = height - content.offsetHeight / 2;

--- a/pages/docs/[...slug].js
+++ b/pages/docs/[...slug].js
@@ -41,7 +41,14 @@ function SidebarRoutes({ isMobile, routes: currentRoutes, level = 1 }) {
       }
 
       return (
-        <Category key={pathname} level={level} title={title} selected={selected} opened={opened}>
+        <Category
+          key={pathname}
+          isMobile={isMobile}
+          level={level}
+          title={title}
+          selected={selected}
+          opened={opened}
+        >
           <SidebarRoutes isMobile={isMobile} routes={routes} level={level + 1} />
         </Category>
       );


### PR DESCRIPTION
`scrollIntoView` works but it also scrolls the page if it has a scroll, the documentation was constantly moving just by navigating using the sidebar, that was fixed by using `offsetTop` instead.

Improved alignment for the sidebar in mobile, it's now more pixel perfect, and the spacing after selecting a category.