### PR TITLE
Rename zeit.co/new → zeit.co/import

### DIFF
--- a/components/banner.js
+++ b/components/banner.js
@@ -13,7 +13,7 @@ const Banner = () => {
         </a>
 
         <a
-          href="https://zeit.co/new?filter=next.js&utm_source=next-site&utm_medium=banner&utm_campaign=next-website"
+          href="https://zeit.co/import?filter=next.js&utm_source=next-site&utm_medium=banner&utm_campaign=next-website"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/components/server-side-rendering/scalable.js
+++ b/components/server-side-rendering/scalable.js
@@ -20,7 +20,7 @@ export default function Scalable() {
               Next.js supports serverless builds out of the box. Simply set the target and Next.js
               will output an SSR-equipped lambda for each page which can be instantly deployed to
               platforms like{' '}
-              <ExternalLink href="https://zeit.co/new?filter=next.js&utm_source=next-site&utm_medium=link&utm_campaign=next-website">
+              <ExternalLink href="https://zeit.co/import?filter=next.js&utm_source=next-site&utm_medium=link&utm_campaign=next-website">
                 ZEIT Now
               </ExternalLink>
               .


### PR DESCRIPTION
We're replacing https://zei.co/new to https://zei.co/import - I did VSCode search and replace.

[PRODUCT-1248](https://zeit.atlassian.net/browse/PRODUCT-1248)