### PR TITLE
Make the feedback UI always expand from the center

### DIFF
--- a/components/header-feedback.js
+++ b/components/header-feedback.js
@@ -289,7 +289,7 @@ class HeaderFeedback extends Component {
             <style jsx>
               {`
                 .geist-feedback-input {
-                  --open-width: 260px;
+                  --open-width: 310px;
                   --open-height: 174px;
                   --closed-width: 90px;
                   --closed-height: 32px;
@@ -367,6 +367,7 @@ class HeaderFeedback extends Component {
                 }
 
                 .geist-feedback-input.focused .textarea-wrapper {
+                  transform: translateX(calc((var(--closed-width) - var(--open-width)) / 2));
                   display: flex;
                   flex-direction: column;
                   border: none;
@@ -492,16 +493,6 @@ class HeaderFeedback extends Component {
                   }
                   to {
                     opacity: 1;
-                  }
-                }
-
-                @media (max-width: 1140px) {
-                  .geist-feedback-input {
-                    --open-width: 310px;
-                  }
-
-                  .geist-feedback-input.focused .textarea-wrapper {
-                    transform: translateX(calc((var(--closed-width) - var(--open-width)) / 2));
                   }
                 }
               `}


### PR DESCRIPTION
This is an update to https://github.com/zeit/next-site/pull/584. @evilrabbit suggested that the feedback UI for Next.js site should always expand from the center, instead of expanding from the left on larger screens. 

![Kapture 2020-02-24 at 16 55 04](https://user-images.githubusercontent.com/992008/75204697-6bf7d800-5726-11ea-9911-175fc4e216b7.gif)
