### PR TITLE
add a link to the quotes.json file in the fetching-api-routes tutorial

### DIFF
--- a/pages/learn/basics/api-routes/fetching-api-routes.mdx
+++ b/pages/learn/basics/api-routes/fetching-api-routes.mdx
@@ -19,6 +19,8 @@ First, if you didn't clone the starter code [earlier in this lesson](/learn/basi
 npm install swr
 ```
 
+If you haven't cloned the starter code, you will also need to [copy the `quotes.json` from GitHub](https://github.com/zeit/next-learn-demo/blob/master/7.2-api-routes/quotes.json). 
+
 Open `pages/api/randomQuote.js` and replace its content with the following:
 
 ```js

--- a/pages/learn/basics/api-routes/fetching-api-routes.mdx
+++ b/pages/learn/basics/api-routes/fetching-api-routes.mdx
@@ -19,7 +19,7 @@ First, if you didn't clone the starter code [earlier in this lesson](/learn/basi
 npm install swr
 ```
 
-If you haven't cloned the starter code, you will also need to [copy the `quotes.json` from GitHub](https://github.com/zeit/next-learn-demo/blob/master/7.2-api-routes/quotes.json). 
+If you haven't cloned the starter code, you will also need to [copy the `quotes.json` file from GitHub](https://github.com/zeit/next-learn-demo/blob/master/7.2-api-routes/quotes.json). 
 
 Open `pages/api/randomQuote.js` and replace its content with the following:
 


### PR DESCRIPTION
I wanted to add a link to the `quotes.json` file for anyone who is working on this tutorial who hasn't downloaded starter code as this particular file did not exist in previous tutorial and I think like the call out to install `swr` it's worth mentioning.

I was not sure if should link to permalink like:   https://github.com/zeit/next-learn-demo/blob/fff295f30e2a488a8b1f2b6ec64acfb62f20ca9f/7.2-api-routes/quotes.json or just leave it as: https://github.com/zeit/next-learn-demo/blob/master/7.2-api-routes/quotes.json