### PR TITLE
import without file extension to support jsx

### DIFF
--- a/pages/learn/basics/create-dynamic-pages/use-router.mdx
+++ b/pages/learn/basics/create-dynamic-pages/use-router.mdx
@@ -15,7 +15,7 @@ In the following example you can see `useRouter` being added to a component othe
 
 ```jsx
 import { useRouter } from 'next/router';
-import Layout from '../components/MyLayout.js';
+import Layout from '../components/MyLayout';
 
 const Content = () => {
   const router = useRouter();


### PR DESCRIPTION
Removed hardcoded file extension to allow for `.jsx` imports out-of-the-box.