### PR TITLE
Rename `functional component` -> `function component`

### DIFF
--- a/components/docs/docs.mdx
+++ b/components/docs/docs.mdx
@@ -450,7 +450,7 @@ function About() {
 export default About
 ```
 
-Note: if passing a functional component as a child of `<Link>` you will need to wrap it in [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref)
+Note: if passing a function component as a child of `<Link>` you will need to wrap it in [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref)
 
 **Example with `React.forwardRef`**
 
@@ -829,7 +829,7 @@ componentDidUpdate(prevProps) {
   </ul>
 </details>
 
-If you want to access the `router` object inside any functional component in your app, you can use the `useRouter` hook, here's how to use it:
+If you want to access the `router` object inside any function component in your app, you can use the `useRouter` hook, here's how to use it:
 
 ```jsx
 import { useRouter } from 'next/router'
@@ -855,7 +855,7 @@ export default function ActiveLink({ children, href }) {
 ```
 
 > **Note**: `useRouter` is a React hook, meaning it cannot be used with classes.
-> You can either use [`withRouter`](#using-a-higher-order-component) (a higher order component) or wrap your class in a functional component.
+> You can either use [`withRouter`](#using-a-higher-order-component) (a higher order component) or wrap your class in a function component.
 
 The above `router` object comes with an API similar to [`next/router`](#imperatively).
 

--- a/pages/learn/basics/create-dynamic-pages/use-router.mdx
+++ b/pages/learn/basics/create-dynamic-pages/use-router.mdx
@@ -9,7 +9,7 @@ export const meta = {
 
 ## useRouter
 
-As you can see, [useRouter](https://nextjs.org/docs/api-reference/next/router#userouter) allows you to access the `router` object inside the page, it's a [React Hook](https://reactjs.org/docs/hooks-intro.html), and it works with functional components.
+As you can see, [useRouter](https://nextjs.org/docs/api-reference/next/router#userouter) allows you to access the `router` object inside the page, it's a [React Hook](https://reactjs.org/docs/hooks-intro.html), and it works with function components.
 
 In the following example you can see `useRouter` being added to a component other than the exported page:
 


### PR DESCRIPTION
This is a follow-up to #415.

See the following for context:

- https://reactjs.org/docs/components-and-props.html#function-and-class-components
- https://overreacted.io/how-are-function-components-different-from-classes/
- https://twitter.com/dan_abramov/status/1057625147216220162
- https://twitter.com/kentcdodds/status/1136274289965928448