### PR TITLE
Fix error in form input example

### DIFF
--- a/pages/learn/basics/api-routes/api-routes-details.mdx
+++ b/pages/learn/basics/api-routes/api-routes-details.mdx
@@ -23,7 +23,7 @@ A good use case for API Routes is handling form input. For example, you can crea
 
 ```js
 export default (req, res) => {
-  const email = res.body.email
+  const email = req.body.email
   // Then save email to your database, etc...
 }
 ```


### PR DESCRIPTION
Tiny bug in the form input example. The response was referenced instead of request.