### PR TITLE
Feature: Add copy button to code blocks in tutorial

### DIFF
--- a/components/learn/Markdown.js
+++ b/components/learn/Markdown.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MDXProvider } from '@mdx-js/tag';
+import MarkdownCopyButton from './MarkdownCopyButton';
 
 const A = ({ children, ...props }) => (
   <a target="_blank" rel="noopener noreferrer" {...props}>
@@ -74,47 +75,55 @@ const Blockquote = ({ children }) => (
   </blockquote>
 );
 
-const Code = ({ children }) => (
-  <pre>
-    <code>{children}</code>
-    <style jsx>{`
-      pre {
-        background: #1d1f21;
-        color: #f8f8f2;
-        white-space: pre;
-        overflow: auto;
-        padding: 1.5rem;
-        margin: 40px 0;
-        border-radius: 5px;
-        -webkit-overflow-scrolling: touch;
-      }
-      pre code {
-        padding: 0;
-        border-radius: 0;
-      }
-      pre code::before {
-        content: '';
-      }
-      pre code::after {
-        content: '';
-      }
-      /* Allow selecting all text for easy copy-pasting.
-         Right now, only enable it for CSS / Markdown because
-         for JS code, you might not want to copy
-         all the lines in a snippet.
-
-         Workaround: For shell scripts,
-         - Use "shell" for one-liners to allow users to copy easily
-         - Use "bash" for multi-liners so they can select each line
-         */
-      :global(.language-css) pre,
-      :global(.language-shell) pre,
-      :global(.language-md) pre {
-        user-select: all;
-      }
-    `}</style>
-  </pre>
-);
+const Code = ({ children }) => {
+  return (
+    <div>
+      <MarkdownCopyButton md={children} />
+      <pre>
+        <code>{children}</code>
+      </pre>
+      <style jsx>{`
+        div {
+          position: relative;
+        }
+        pre {
+          background: #1d1f21;
+          color: #f8f8f2;
+          white-space: pre;
+          overflow: auto;
+          padding: 1.5rem;
+          margin: 40px 0;
+          border-radius: 5px;
+          -webkit-overflow-scrolling: touch;
+        }
+        pre code {
+          padding: 0;
+          border-radius: 0;
+        }
+        pre code::before {
+          content: '';
+        }
+        pre code::after {
+          content: '';
+        }
+        /* Allow selecting all text for easy copy-pasting.
+        Right now, only enable it for CSS / Markdown because
+        for JS code, you might not want to copy
+        all the lines in a snippet.
+        
+        Workaround: For shell scripts,
+        - Use "shell" for one-liners to allow users to copy easily
+        - Use "bash" for multi-liners so they can select each line
+        */
+        :global(.language-css) pre,
+        :global(.language-shell) pre,
+        :global(.language-md) pre {
+          user-select: all;
+        }
+      `}</style>
+    </div>
+  );
+};
 
 const InlineCode = ({ children }) => (
   <code>

--- a/components/learn/MarkdownCopyButton.js
+++ b/components/learn/MarkdownCopyButton.js
@@ -25,7 +25,7 @@ const MarkdownCopyButton = ({ md }) => {
           top: 0;
           right: 0;
           border-radius: 0px;
-          padding: 0.75rem 1rem;
+          padding: 0.5rem 1rem;
           border: 0px;
           background: #0070f3;
           color: white;
@@ -50,7 +50,7 @@ const MarkdownCopyButton = ({ md }) => {
 
         @media (max-width: 960px) {
           button {
-            padding: 0.5rem 0.75rem;
+            padding: 0.25rem 0.5rem;
           }
         }
       `}</style>

--- a/components/learn/MarkdownCopyButton.js
+++ b/components/learn/MarkdownCopyButton.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import mdToClipboard from '../../lib/mdToClipboard';
+
+const MarkdownCopyButton = ({ md }) => {
+  const [copyStatus, setCopyStatus] = useState('Copy');
+
+  const copyHandler = () => {
+    mdToClipboard(md);
+    setCopyStatus('Copied');
+    setTimeout(() => {
+      setCopyStatus('Copy');
+    }, 1000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copyHandler}
+      className={copyStatus === 'Copied' ? 'copy-active' : 'copy-inactive'}
+    >
+      {copyStatus}
+      <style jsx>{`
+        button {
+          position: absolute;
+          top: 0;
+          right: 0;
+          border-radius: 0px;
+          padding: 0.75rem 1rem;
+          border: 0px;
+          background: #0070f3;
+          color: white;
+          transition: 0.2s;
+          cursor: pointer;
+          border-radius: 0px 5px 0px 5px;
+          min-width: 5rem;
+          user-select: none;
+        }
+
+        button:active {
+          outline: none;
+        }
+
+        .copy-inactive:hover {
+          background: rgba(0, 118, 255, 0.9);
+        }
+
+        .copy-active {
+          background: green;
+        }
+
+        @media (max-width: 960px) {
+          button {
+            padding: 0.5rem 0.75rem;
+          }
+        }
+      `}</style>
+    </button>
+  );
+};
+
+export default MarkdownCopyButton;

--- a/components/learn/MarkdownCopyButton.js
+++ b/components/learn/MarkdownCopyButton.js
@@ -25,7 +25,7 @@ const MarkdownCopyButton = ({ md }) => {
           top: 0;
           right: 0;
           border-radius: 0px;
-          padding: 0.5rem 1rem;
+          padding: 0.35rem 1rem;
           border: 0px;
           background: #0070f3;
           color: white;

--- a/components/learn/MarkdownCopyButton.js
+++ b/components/learn/MarkdownCopyButton.js
@@ -1,24 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import mdToClipboard from '../../lib/mdToClipboard';
 
 const MarkdownCopyButton = ({ md }) => {
-  const [copyStatus, setCopyStatus] = useState('Copy');
-
   const copyHandler = () => {
     mdToClipboard(md);
-    setCopyStatus('Copied');
-    setTimeout(() => {
-      setCopyStatus('Copy');
-    }, 1000);
   };
-
   return (
-    <button
-      type="button"
-      onClick={copyHandler}
-      className={copyStatus === 'Copied' ? 'copy-active' : 'copy-inactive'}
-    >
-      {copyStatus}
+    <button type="button" onClick={copyHandler}>
+      Copy
       <style jsx>{`
         button {
           position: absolute;
@@ -29,22 +18,17 @@ const MarkdownCopyButton = ({ md }) => {
           border: 0px;
           background: #0070f3;
           color: white;
-          transition: 0.2s;
           cursor: pointer;
           border-radius: 0px 5px 0px 5px;
-          min-width: 5rem;
+          transition: 0.2s;
           user-select: none;
         }
 
+        button:hover {
+          background: rgb(18, 124, 247);
+        }
+
         button:active {
-          outline: none;
-        }
-
-        .copy-inactive:hover {
-          background: rgba(0, 118, 255, 0.9);
-        }
-
-        .copy-active {
           background: green;
         }
 

--- a/lib/mdToClipboard.js
+++ b/lib/mdToClipboard.js
@@ -1,0 +1,33 @@
+const markdownToString = code => {
+  return code
+    .map(text => {
+      if (text instanceof Object) {
+        if (text.props.children instanceof Object) {
+          if (text.props.children.length > 1) {
+            return markdownToString(text.props.children);
+          }
+          return text.props.children.props.children;
+        }
+        return text.props.children;
+      }
+      return text;
+    })
+    .flat()
+    .join('');
+};
+
+const copyToClipboard = code => {
+  const str = markdownToString(code);
+
+  const el = document.createElement('textarea');
+  el.value = str;
+  el.setAttribute('readonly', '');
+  el.style.position = 'absolute';
+  el.style.left = '-9999px';
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand('copy');
+  document.body.removeChild(el);
+};
+
+export default copyToClipboard;


### PR DESCRIPTION
Created a button and function to copy a code block directly to a user's clipboard in the tutorial

Previous:
![image](https://user-images.githubusercontent.com/49853724/80534827-1970ad00-895d-11ea-91c5-6b69a8abbccd.png)

Created:
![image](https://user-images.githubusercontent.com/49853724/80534975-4c1aa580-895d-11ea-8ce3-6b9033f8bfee.png)

Fixes #597